### PR TITLE
dealing with taxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*.swp

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,6 +275,24 @@ impl Mul<Currency> for i64 {
     }
 }
 
+impl Mul<f64> for Currency {
+    type Output = Currency;
+
+    #[inline]
+    fn mul(self, rhs: f64) -> Currency {
+        Currency(self.0, (self.1 as f64 * rhs).round() as i64)
+    }
+}
+
+impl Mul<Currency> for f64 {
+    type Output = Currency;
+
+    #[inline]
+    fn mul(self, rhs: Currency) -> Currency {
+        rhs * self
+    }
+}
+
 /// Overloads the '/' operator for Currency objects.
 ///
 /// Allows a Currency to be divided by an i64.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,11 @@ use std::fmt::LowerExp;
 use std::fmt::Formatter;
 use std::fmt::Result;
 
-use std::marker::Copy;
-
 /// Represents currency through an optional symbol and amount of coin.
 ///
 /// Each 100 coins results in a banknote. (100 is formatted as 1.00)
 /// The currency will be formatted as such: `Currency(Some('$'), 432)` ==> "$4.32"
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Currency(pub Option<char>, pub i64);
 
 impl Currency {
@@ -41,10 +39,10 @@ impl Currency {
         Currency(None, 0)
     }
 
-    /// Uses a Regular Expression to parse a string literal (&str) and attempts to turn it into a 
+    /// Uses a Regular Expression to parse a string literal (&str) and attempts to turn it into a
     /// currency. Returns `Some(Currency)` on a successful conversion, otherwise `None`.
     ///
-    /// If the currency is intended to be a negative amount, ensure the '-' is the first character 
+    /// If the currency is intended to be a negative amount, ensure the '-' is the first character
     /// in the string.
     /// The Regex recognizes European notation (€1,00)
     ///
@@ -64,7 +62,7 @@ impl Currency {
 
         // Shadow s with a trimmed version
         let s = s.trim();
-        let re = 
+        let re =
             Regex::new(r"(?:\b|(-)?)(\p{Sc})?((?:(?:\d{1,3}[\.,])+\d{3})|\d+)(?:[\.,](\d{2}))?\b")
             .unwrap();
 
@@ -107,7 +105,7 @@ impl Currency {
     }
 }
 
-/// Allows Currencies to be displayed as Strings. The format includes no comma delimiting with a 
+/// Allows Currencies to be displayed as Strings. The format includes no comma delimiting with a
 /// two digit precision decimal.
 ///
 /// # Examples
@@ -134,7 +132,7 @@ impl Display for Currency {
     }
 }
 
-/// Identical to the implementation of Display, but replaces the "." with a ",". Access this 
+/// Identical to the implementation of Display, but replaces the "." with a ",". Access this
 /// formating by using "{:e}".
 ///
 /// # Examples
@@ -157,7 +155,7 @@ impl LowerExp for Currency {
 /// Overloads the '==' operator for Currency objects.
 ///
 /// # Panics
-/// Panics if the two comparators are different types of currency, as denoted by the Currency's 
+/// Panics if the two comparators are different types of currency, as denoted by the Currency's
 /// symbol.
 impl PartialEq<Currency> for Currency {
     #[inline]
@@ -237,7 +235,7 @@ impl Add for Currency {
 /// Overloads the '-' operator for Currency objects.
 ///
 /// # Panics
-/// Panics if the minuend and subtrahend are two different types of currency, as denoted by the 
+/// Panics if the minuend and subtrahend are two different types of currency, as denoted by the
 /// Currency's symbol.
 impl Sub for Currency {
     type Output = Currency;
@@ -288,12 +286,3 @@ impl Div<i64> for Currency {
         Currency(self.0, self.1 / rhs)
     }
 }
-
-/// Allows Currencies to be copied, rather than using move semantics.
-impl Copy for Currency { }
-impl Clone for Currency {
-    #[inline]
-    fn clone(&self) -> Currency { *self }
-}
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl Mul<f64> for Currency {
 
     #[inline]
     fn mul(self, rhs: f64) -> Currency {
-        Currency(self.0, (self.1 as f64 * rhs).round() as i64)
+        Currency(self.0, (self.1 as f64 * rhs).ceil() as i64)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,14 @@
-﻿#![crate_type = "lib"]
-#![crate_name = "currency"]
+﻿//! This provides a simple type that encodes a currency.
+
+#![deny(
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_import_braces,
+    unused_qualifications
+    )]
+
 
 extern crate regex;
 
@@ -275,12 +284,13 @@ impl Mul<Currency> for i64 {
     }
 }
 
+/// Multiplies with float, probably not a good idea, help appreciated.
 impl Mul<f64> for Currency {
     type Output = Currency;
 
     #[inline]
     fn mul(self, rhs: f64) -> Currency {
-        Currency(self.0, (self.1 as f64 * rhs).ceil() as i64)
+        Currency(self.0, (self.1 as f64 * rhs).round() as i64)
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,6 +4,22 @@ use currency::Currency;
 use std::cmp::Ordering;
 
 #[test]
+fn taxes() {
+    let a = Currency(Some('$'), 1000);
+    let b = Currency(Some('$'), 1190);
+
+    fn foo(n:f64) -> i64{
+        (n*1000f64).abs() as i64
+    }
+
+    assert_eq!(1*foo(1.19), 1190);
+    assert_eq!(a*1.19, b);
+    assert_eq!(1.19*a, b);
+    assert_eq!(a*1.1901, b);
+    assert_eq!(1.1901*a, b);
+}
+
+#[test]
 fn eq_works() {
     let a = Currency(Some('$'), 1210);
     let b = Currency(Some('$'), 1210);


### PR DESCRIPTION
Hi there,
I've been working with my one fork of this lib for a while, to which I had added to possibility to multiply with `f64`, to deal with taxes.
However, I'm not sure if this is really a good idea.
Alternatively this could use something like a `BigInt` or `BigRational` from [num](https://crates.io/crates/num)..
I'm also not sure about the operation to turn the resulting floats back into `i64`, whether or not to use `ceil()`, `floor()` or just `round()`.

If you have no strong opinion about this I would ask someone at the Rust users forum [for participation](https://users.rust-lang.org/t/twir-call-for-participation/).
