### PR TITLE
(feat) Treat parens in from_str like negative sign

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -800,6 +800,8 @@ mod tests {
         assert_eq!(expected, actual);
         let actual = Currency::from_str("($12,000.99)").unwrap();
         assert_eq!(expected, actual);
+        let actual = Currency::from_str("$(12,000.99)").unwrap();
+        assert_eq!(expected, actual);
 
         let expected = Currency { symbol: Some('$'), coin: BigInt::from(-1210) };
         let actual = Currency::from_str("-$12.10").unwrap();


### PR DESCRIPTION
## What It Does

Allows strings like `"(12.10)"` to be parsed as negative `Currency` values.

## Why?

Because in some financial/accounting applications, currency is treated this way. Also this crate is the best Rust library on crates.io for parsing currency strings into meaningful types.

## Limitations

I tried to follow the pattern I've inferred from the source code -- specifically to try not to fail on oddly formatted data instead of returning parsing errors. This means that there are tons of strings which will be successfully parsed by `Currency::from_str` which would look wrong to a human. See the new test cases for all the examples I could think of. Here's the most zany examples I could think of:

 * `")this is a Currency struct with 0 bigint value inside"` -> `Currency { symbol: None, biginit::from(0) }`
 * `"(((($1"` -> `Currency { symbol: Some('$'), biginit::from(-100) }`

I'm not sure I feel _great_ about this approach, and I'm very happy to change the implementation to add some strictness / sanity check :-)